### PR TITLE
make Index Translator extend serializable.

### DIFF
--- a/src/org/python/core/PyUnicode.java
+++ b/src/org/python/core/PyUnicode.java
@@ -140,7 +140,7 @@ public class PyUnicode extends PyString implements Iterable {
      * Index translation between code point index (as seen by Python) and UTF-16 index (as used in
      * the Java String.
      */
-    private interface IndexTranslator {
+    private interface IndexTranslator extends Serializable{
 
         /** Number of supplementary characters (hence point code length may be found). */
         public int suppCount();


### PR DESCRIPTION
since beta 4 PyUnicode cannot be serialized because Index translator doens't implement serialiazble.
